### PR TITLE
Add Azure login and registration

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,16 +1,27 @@
 import axios from "axios";
 
-export const API_URL = "https://6837d1402c55e01d184aeb28.mockapi.io";
+// URL base del backend en Azure que manejará usuarios y datos
+export const API_URL = "https://tu-backend-azure.azurewebsites.net/api";
 
-
-// LOGIN FAKE PARA DEMO
+// Autenticación consultando el backend en Azure
 export async function login(username, password) {
-  // Aquí deberías consultar una API real de usuarios
-  if (username === "admin" && password === "admin") {
-    return { success: true, rol: "admin" };
-  } else if (username === "trabajador" && password === "trabajador") {
-    return { success: true, rol: "trabajador" };
-  } else {
+  try {
+    const res = await axios.post(`${API_URL}/login`, { username, password });
+    return res.data;
+  } catch (e) {
+    return { success: false };
+  }
+}
+
+// Registro de usuarios en Azure
+export async function register(username, password) {
+  try {
+    const res = await axios.post(`${API_URL}/users`, {
+      username,
+      password
+    });
+    return res.data;
+  } catch (e) {
     return { success: false };
   }
 }

--- a/components/RegisterForm.js
+++ b/components/RegisterForm.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { View, TextInput, Button, Text, StyleSheet } from "react-native";
+import { Formik } from "formik";
+
+const RegisterForm = ({ onSubmit }) => (
+  <Formik
+    initialValues={{ username: "", password: "", confirm: "" }}
+    onSubmit={values => onSubmit(values)}
+  >
+    {({ handleChange, handleBlur, handleSubmit, values }) => (
+      <View style={styles.container}>
+        <Text style={styles.title}>Crear cuenta</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Usuario"
+          onChangeText={handleChange("username")}
+          onBlur={handleBlur("username")}
+          value={values.username}
+          autoCapitalize="none"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Contraseña"
+          onChangeText={handleChange("password")}
+          onBlur={handleBlur("password")}
+          value={values.password}
+          secureTextEntry
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Confirmar contraseña"
+          onChangeText={handleChange("confirm")}
+          onBlur={handleBlur("confirm")}
+          value={values.confirm}
+          secureTextEntry
+        />
+        <Button title="Registrar" onPress={handleSubmit} />
+      </View>
+    )}
+  </Formik>
+);
+
+const styles = StyleSheet.create({
+  container: { padding: 24, flex: 1, justifyContent: "center" },
+  title: { fontSize: 28, marginBottom: 20, textAlign: "center" },
+  input: { borderWidth: 1, borderRadius: 8, padding: 10, marginBottom: 16 }
+});
+
+export default RegisterForm;

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import LoginScreen from '../screens/LoginScreen';
+import RegisterScreen from '../screens/RegisterScreen';
 import BottomTabs from './BottomTabs';
 
 const Stack = createStackNavigator();
@@ -9,6 +10,7 @@ export default function AppNavigator() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Login" component={LoginScreen} />
+      <Stack.Screen name="Register" component={RegisterScreen} />
       <Stack.Screen name="Main" component={BottomTabs} />
     </Stack.Navigator>
   );

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Alert } from "react-native";
+import { Alert, View, Button } from "react-native";
 import LoginForm from "../components/LoginForm";
 import { login } from "../api/api";
 
@@ -12,5 +12,13 @@ export default function LoginScreen({ navigation }) {
       Alert.alert("Error", "Usuario o contraseña incorrectos");
     }
   };
-  return <LoginForm onSubmit={handleLogin} />;
+  return (
+    <View style={{ flex: 1 }}>
+      <LoginForm onSubmit={handleLogin} />
+      <Button
+        title="Registrarse"
+        onPress={() => navigation.navigate("Register")}
+      />
+    </View>
+  );
 }

--- a/screens/RegisterScreen.js
+++ b/screens/RegisterScreen.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { Alert } from "react-native";
+import RegisterForm from "../components/RegisterForm";
+import { register } from "../api/api";
+
+export default function RegisterScreen({ navigation }) {
+  const handleRegister = async values => {
+    if (values.password !== values.confirm) {
+      Alert.alert("Error", "Las contraseñas no coinciden");
+      return;
+    }
+    const res = await register(values.username, values.password);
+    if (res.success) {
+      Alert.alert("Éxito", "Usuario registrado correctamente");
+      navigation.goBack();
+    } else {
+      Alert.alert("Error", "No se pudo registrar el usuario");
+    }
+  };
+
+  return <RegisterForm onSubmit={handleRegister} />;
+}


### PR DESCRIPTION
## Summary
- connect login and registration with an Azure backend
- add register API function
- create registration form and screen
- allow navigating to Register screen from Login
- expose Register screen through the navigator

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f8af495d8832d99f274a7d48f135a